### PR TITLE
Feat/affordance extension

### DIFF
--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -12,15 +12,28 @@ service XAPI {
   rpc Disconnect (Empty) returns (Empty);
   
   // Read services
+  rpc GetCollisionSensitivity (Empty) returns (CollisionSensitivity);
+  rpc GetTeachSensitivity (Empty) returns (TeachSensitivity);
+
   rpc GetVersion (Empty) returns (Version);
   rpc GetState (Empty) returns (State);
+  rpc GetCmdnum (Empty) returns (Cmdnum);
+  rpc GetServoAngles (Empty) returns (ServoAngles);
   rpc GetPosition (Empty) returns (Position);
-  
+
   // Write services
   rpc SetMotionEnable (MotionEnable) returns (MotionEnable);
   rpc SetState (State) returns (State);
   rpc SetMode (Mode) returns (Mode);
+  rpc SetCollisionSensitivity (CollisionSensitivity) returns (CollisionSensitivity);
+  rpc SetTeachSensitivity (TeachSensitivity) returns (TeachSensitivity);
+
   rpc SetPosition (Position) returns (Position);
+  rpc SetServoAngles (ServoAngles) returns (ServoAngles);
+  rpc MoveCircle (MoveCircleMsg) returns (MoveCircleMsg);
+
+  rpc Reset (ResetMsg) returns (Empty);
+  rpc EmergencyStop (Empty) returns (Empty);
 
 
 }
@@ -45,6 +58,16 @@ message InitParam {
   string report_type = 14;
 }
 
+message CollisionSensitivity{
+  int32 status_code = 1;
+  int32 collision_sensitivity = 2;
+}
+
+message TeachSensitivity{
+  int32 status_code = 1;
+  int32 teach_sensitivity = 2;
+}
+
 message Version {
   int32 status_code = 1;
   string version = 2;
@@ -55,7 +78,15 @@ message State {
   int32 state = 2;
 }
 
+message Cmdnum {
+  int32 status_code = 1;
+  int32 cmdnum = 2;
+}
+
+
+
 message Position {
+  // TODO(jo-bru): add oneof to handle polymorphism
   int32 status_code = 1;
   float x = 2;
   float y = 3;
@@ -64,6 +95,36 @@ message Position {
   float pitch = 6;
   float yaw = 7;
   bool wait = 8;
+}
+
+message ServoAngles {
+  // TODO(jo-bru): add oneof to handle polymorphism
+  int32 status_code = 1;
+  float servo_1 = 2;
+  float servo_2 = 3;
+  float servo_3 = 4;
+  float servo_4 = 5;
+  float servo_5 = 6;
+  float servo_6 = 7;
+  float servo_7 = 8;
+  bool wait = 9;
+}
+
+message MoveCircleMsg {
+  int32 status_code = 1;
+  Position pose_1 = 2;
+  Position pose_2 = 3;
+  float percent = 4;
+  float speed = 5;
+  float acc = 6;
+  bool wait = 7;
+  float timeout = 8;
+}
+
+message ResetMsg {
+  int32 status_code = 1;
+  bool wait = 2;
+  float timeout = 3;
 }
 
 message MotionEnable {

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -32,8 +32,7 @@ service XAPI {
   rpc GetPosition (Empty) returns (Position);
 
   // Write services
-  rpc SetDefaultIsRadian (DefaultIsRadian) returns (DefaultIsRadian);
-
+  //  rpc SetDefaultIsRadian (DefaultIsRadian) returns (DefaultIsRadian); // DEACTIVATED!
 
   rpc SetMotionEnable (MotionEnable) returns (MotionEnable);
   rpc SetState (State) returns (State);

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -35,6 +35,9 @@ service XAPI {
   rpc Reset (ResetMsg) returns (Empty);
   rpc EmergencyStop (Empty) returns (Empty);
 
+  rpc GetInverseKinematics (Position) returns (ServoAngles);
+  rpc GetForwardKinematics (ServoAngles) returns (Position);
+
 
 }
 

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -16,7 +16,13 @@ service XAPI {
   rpc GetCollisionSensitivity (Empty) returns (CollisionSensitivity);
   rpc GetTeachSensitivity (Empty) returns (TeachSensitivity);
 
+  rpc GetLastUsedTCPSpeed (Empty) returns (TCPSpeed);
+  rpc GetLastUsedTCPAcc (Empty) returns (TCPAcc);
   rpc GetLastUsedAngles (Empty) returns (ServoAngles);
+  rpc GetLastUsedJointSpeed (Empty) returns (JointSpeed);
+  rpc GetLastUsedJointAcc (Empty) returns (JointAcc);
+  rpc GetLastUsedPosition (Empty) returns (Position);
+
 
   rpc GetTemperatures (Empty) returns (Temperatures);
   rpc GetDefaultIsRadian (Empty) returns (DefaultIsRadian);
@@ -147,6 +153,26 @@ message State {
 message Cmdnum {
   int32 status_code = 1;
   int32 cmdnum = 2;
+}
+
+message TCPSpeed {
+  int32 status_code = 1;
+  float tcp_speed = 2;
+}
+
+message TCPAcc {
+  int32 status_code = 1;
+  float tcp_acc = 2;
+}
+
+message JointSpeed {
+  int32 status_code = 1;
+  float joint_speed = 2;
+}
+
+message JointAcc {
+  int32 status_code = 1;
+  float joint_acc = 2;
 }
 
 message Position {

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -30,10 +30,11 @@ service XAPI {
   rpc SetMotionEnable (MotionEnable) returns (MotionEnable);
   rpc SetState (State) returns (State);
   rpc SetMode (Mode) returns (Mode);
+  rpc SetPauseTime (PauseTime) returns (PauseTime);
   rpc SetCollisionSensitivity (CollisionSensitivity) returns (CollisionSensitivity);
   rpc SetTeachSensitivity (TeachSensitivity) returns (TeachSensitivity);
 
-  rpc SetPosition (Position) returns (Position);
+  rpc SetPosition (SetPositionMsg) returns (SetPositionMsg);
   rpc SetServoAngles (ServoAngles) returns (ServoAngles);
   rpc MoveCircle (MoveCircleMsg) returns (MoveCircleMsg);
 
@@ -137,7 +138,6 @@ message Cmdnum {
 }
 
 message Position {
-  // TODO(jo-bru): add oneof to handle polymorphism
   int32 status_code = 1;
   float x = 2;
   float y = 3;
@@ -145,7 +145,6 @@ message Position {
   float roll = 5;
   float pitch = 6;
   float yaw = 7;
-  bool wait = 8;
 }
 
 message ServoAngles {
@@ -168,6 +167,22 @@ message MotionEnable {
   int32 servo_id = 3;
 }
 
+message PauseTime {
+  int32 status_code = 1;
+  float sltime = 2;
+}
+
+message SetPositionMsg {
+  int32 status_code = 1;
+  Position pose = 2;
+  float radius = 3;
+  float speed = 5;
+  float acc = 6;
+  float mvtime = 7;
+  bool wait = 8;
+  float timeout = 9;
+}
+
 message MoveCircleMsg {
   int32 status_code = 1;
   Position pose_1 = 2;
@@ -175,8 +190,9 @@ message MoveCircleMsg {
   float percent = 4;
   float speed = 5;
   float acc = 6;
-  bool wait = 7;
-  float timeout = 8;
+  float mvtime = 7;
+  bool wait = 8;
+  float timeout = 9;
 }
 
 message ResetMsg {

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -47,6 +47,7 @@ service XAPI {
   rpc SetCollisionSensitivity (CollisionSensitivity) returns (CollisionSensitivity);
   rpc SetTeachSensitivity (TeachSensitivity) returns (TeachSensitivity);
 
+  // Motion Services
   rpc SetPosition (SetPositionMsg) returns (SetPositionMsg);
   rpc SetServoAngle (SetServoAngleMsg) returns (SetServoAngleMsg);
   rpc MoveCircle (MoveCircleMsg) returns (MoveCircleMsg);
@@ -54,9 +55,22 @@ service XAPI {
   rpc Reset (ResetMsg) returns (Empty);
   rpc EmergencyStop (Empty) returns (Empty);
 
+  // Kinematics
   rpc GetInverseKinematics (Position) returns (ServoAngles);
   rpc GetForwardKinematics (ServoAngles) returns (Position);
 
+  // Reduced Mode
+  rpc SetReducedMode (ReducedMode) returns (ReducedMode);
+  rpc SetReducedMaxTCPSpeed (TCPSpeed) returns (TCPSpeed);
+  rpc SetReducedMaxJointSpeed (JointSpeed) returns (JointSpeed);
+  rpc GetReducedMode (Empty) returns (ReducedMode);
+  rpc GetReducedStates (Empty) returns (ReducedStates);
+  rpc SetReducedTCPBoundary (TCPBoundary) returns (TCPBoundary);
+  //rpc SetReducedJointRange (JointRange) returns (JointRange); //TODO
+
+  rpc SetFenceMode (FenceMode) returns (FenceMode); // TODO: how to getFenceMode ?
+
+  // Simulation Robot
   rpc GetSimulationRobot (Empty) returns (SimulationRobot);
   rpc SetSimulationRobot (SimulationRobot) returns (SimulationRobot);
 
@@ -254,6 +268,37 @@ message ResetMsg {
   int32 status_code = 1;
   bool wait = 2;
   float timeout = 3;
+}
+
+message ReducedMode {
+  int32 status_code = 1;
+  bool on = 2;
+}
+
+message ReducedStates {
+  int32 status_code = 1;
+  bool on = 2;
+  TCPBoundary xyz_list= 3;
+  TCPSpeed tcp_speed= 4;
+  JointSpeed joint_speed = 5;
+  //JRange jrange = 6; // TODO
+  //bool fense_is_on = 7; //TODO
+  //collision_rebount_is_on = 8; // TODO 
+}
+
+message TCPBoundary {
+  int32 status_code = 1;
+  int32 x_max = 2;
+  int32 x_min = 3;
+  int32 y_max = 4;
+  int32 y_min = 5;
+  int32 z_max = 6;
+  int32 z_min = 7;
+}
+
+message FenceMode {
+  int32 status_code = 1;
+  bool on = 2;
 }
 
 message SimulationRobot{

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -35,7 +35,7 @@ service XAPI {
   rpc SetTeachSensitivity (TeachSensitivity) returns (TeachSensitivity);
 
   rpc SetPosition (SetPositionMsg) returns (SetPositionMsg);
-  rpc SetServoAngles (ServoAngles) returns (ServoAngles);
+  rpc SetServoAngle (SetServoAngleMsg) returns (SetServoAngleMsg);
   rpc MoveCircle (MoveCircleMsg) returns (MoveCircleMsg);
 
   rpc Reset (ResetMsg) returns (Empty);
@@ -148,7 +148,6 @@ message Position {
 }
 
 message ServoAngles {
-  // TODO(jo-bru): add oneof to handle polymorphism
   int32 status_code = 1;
   float servo_1 = 2;
   float servo_2 = 3;
@@ -157,7 +156,11 @@ message ServoAngles {
   float servo_5 = 6;
   float servo_6 = 7;
   float servo_7 = 8;
-  bool wait = 9;
+}
+
+message ServoAngle {
+    int32 servo_id = 1;
+    float angle = 2;
 }
 
 
@@ -181,6 +184,20 @@ message SetPositionMsg {
   float mvtime = 7;
   bool wait = 8;
   float timeout = 9;
+}
+
+message SetServoAngleMsg {
+  int32 status_code = 1;
+  oneof input {
+      ServoAngles servo_angles = 2;
+      ServoAngle servo_angle = 3;
+  }
+  float speed = 4;
+  float acc = 5;
+  float mvtime = 6;
+  bool wait = 7;
+  float timeout = 8;
+  float radius = 9;
 }
 
 message MoveCircleMsg {

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -38,6 +38,9 @@ service XAPI {
   rpc GetInverseKinematics (Position) returns (ServoAngles);
   rpc GetForwardKinematics (ServoAngles) returns (Position);
 
+  rpc GetSimulationRobot (Empty) returns (SimulationRobot);
+  rpc SetSimulationRobot (SimulationRobot) returns (SimulationRobot);
+
 
 }
 
@@ -86,8 +89,6 @@ message Cmdnum {
   int32 cmdnum = 2;
 }
 
-
-
 message Position {
   // TODO(jo-bru): add oneof to handle polymorphism
   int32 status_code = 1;
@@ -113,6 +114,18 @@ message ServoAngles {
   bool wait = 9;
 }
 
+
+message MotionEnable {
+  int32 status_code = 1;
+  int32 enable = 2;
+  int32 servo_id = 3;
+}
+
+message Mode {
+  int32 status_code = 1;
+  int32 mode = 2;
+}
+
 message MoveCircleMsg {
   int32 status_code = 1;
   Position pose_1 = 2;
@@ -130,15 +143,9 @@ message ResetMsg {
   float timeout = 3;
 }
 
-message MotionEnable {
+message SimulationRobot{
   int32 status_code = 1;
-  int32 enable = 2;
-  int32 servo_id = 3;
-}
-
-message Mode {
-  int32 status_code = 1;
-  int32 mode = 2;
+  bool on = 2;
 }
 
 // See the definition of the status_code at

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -70,6 +70,12 @@ service XAPI {
 
   rpc SetFenceMode (FenceMode) returns (FenceMode); // TODO: how to getFenceMode ?
 
+  // counter
+  rpc GetCounter (Empty) returns (Counter);
+  rpc SetCounterReset (Empty) returns (Counter);
+  rpc SetCounterIncrease (Empty) returns (Counter);
+
+
   // Simulation Robot
   rpc GetSimulationRobot (Empty) returns (SimulationRobot);
   rpc SetSimulationRobot (SimulationRobot) returns (SimulationRobot);
@@ -299,6 +305,11 @@ message TCPBoundary {
 message FenceMode {
   int32 status_code = 1;
   bool on = 2;
+}
+
+message Counter {
+  int32 status_code = 1;
+  int32 counter = 2;
 }
 
 message SimulationRobot{

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -40,7 +40,7 @@ service XAPI {
   // Write services
   //  rpc SetDefaultIsRadian (DefaultIsRadian) returns (DefaultIsRadian); // DEACTIVATED!
 
-  rpc SetMotionEnable (MotionEnable) returns (MotionEnable);
+  rpc MotionEnable (MotionEnableMsg) returns (MotionEnableMsg);
   rpc SetState (State) returns (State);
   rpc SetMode (Mode) returns (Mode);
   rpc SetPauseTime (PauseTime) returns (PauseTime);
@@ -221,8 +221,7 @@ message ServoAngle {
     float angle = 2;
 }
 
-
-message MotionEnable {
+message MotionEnableMsg {
   int32 status_code = 1;
   int32 enable = 2;
   int32 servo_id = 3;

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -15,7 +15,12 @@ service XAPI {
   rpc GetMode (Empty) returns (Mode);
   rpc GetCollisionSensitivity (Empty) returns (CollisionSensitivity);
   rpc GetTeachSensitivity (Empty) returns (TeachSensitivity);
+
+  rpc GetLastUsedAngles (Empty) returns (ServoAngles);
+
   rpc GetTemperatures (Empty) returns (Temperatures);
+  rpc GetDefaultIsRadian (Empty) returns (DefaultIsRadian);
+
   rpc GetVoltages (Empty) returns (Voltages);
   rpc GetCurrents (Empty) returns (Currents);
 
@@ -27,6 +32,9 @@ service XAPI {
   rpc GetPosition (Empty) returns (Position);
 
   // Write services
+  rpc SetDefaultIsRadian (DefaultIsRadian) returns (DefaultIsRadian);
+
+
   rpc SetMotionEnable (MotionEnable) returns (MotionEnable);
   rpc SetState (State) returns (State);
   rpc SetMode (Mode) returns (Mode);
@@ -93,6 +101,11 @@ message Temperatures {
   float servo_5 = 6;
   float servo_6 = 7;
   float servo_7 = 8;
+}
+
+message DefaultIsRadian {
+  int32 status_code = 1;
+  bool default_is_radian = 2;
 }
 
 message Voltages {

--- a/protos/xapi.proto
+++ b/protos/xapi.proto
@@ -12,10 +12,15 @@ service XAPI {
   rpc Disconnect (Empty) returns (Empty);
   
   // Read services
+  rpc GetMode (Empty) returns (Mode);
   rpc GetCollisionSensitivity (Empty) returns (CollisionSensitivity);
   rpc GetTeachSensitivity (Empty) returns (TeachSensitivity);
+  rpc GetTemperatures (Empty) returns (Temperatures);
+  rpc GetVoltages (Empty) returns (Voltages);
+  rpc GetCurrents (Empty) returns (Currents);
 
   rpc GetVersion (Empty) returns (Version);
+  rpc GetRobotSN (Empty) returns (RobotSN);
   rpc GetState (Empty) returns (State);
   rpc GetCmdnum (Empty) returns (Cmdnum);
   rpc GetServoAngles (Empty) returns (ServoAngles);
@@ -41,7 +46,6 @@ service XAPI {
   rpc GetSimulationRobot (Empty) returns (SimulationRobot);
   rpc SetSimulationRobot (SimulationRobot) returns (SimulationRobot);
 
-
 }
 
 message Empty {
@@ -64,6 +68,11 @@ message InitParam {
   string report_type = 14;
 }
 
+message Mode {
+  int32 status_code = 1;
+  int32 mode = 2;
+}
+
 message CollisionSensitivity{
   int32 status_code = 1;
   int32 collision_sensitivity = 2;
@@ -74,9 +83,47 @@ message TeachSensitivity{
   int32 teach_sensitivity = 2;
 }
 
+message Temperatures {
+  int32 status_code = 1;
+  float servo_1 = 2;
+  float servo_2 = 3;
+  float servo_3 = 4;
+  float servo_4 = 5;
+  float servo_5 = 6;
+  float servo_6 = 7;
+  float servo_7 = 8;
+}
+
+message Voltages {
+  int32 status_code = 1;
+  float servo_1 = 2;
+  float servo_2 = 3;
+  float servo_3 = 4;
+  float servo_4 = 5;
+  float servo_5 = 6;
+  float servo_6 = 7;
+  float servo_7 = 8;
+}
+
+message Currents {
+  int32 status_code = 1;
+  float servo_1 = 2;
+  float servo_2 = 3;
+  float servo_3 = 4;
+  float servo_4 = 5;
+  float servo_5 = 6;
+  float servo_6 = 7;
+  float servo_7 = 8;
+}
+
 message Version {
   int32 status_code = 1;
   string version = 2;
+}
+
+message RobotSN {
+  int32 status_code = 1;
+  string robot_sn = 2;
 }
 
 message State {
@@ -119,11 +166,6 @@ message MotionEnable {
   int32 status_code = 1;
   int32 enable = 2;
   int32 servo_id = 3;
-}
-
-message Mode {
-  int32 status_code = 1;
-  int32 mode = 2;
 }
 
 message MoveCircleMsg {

--- a/tools/xarm-commander/xarm_commander.cc
+++ b/tools/xarm-commander/xarm_commander.cc
@@ -51,7 +51,7 @@ using xapi::InitParam;
 using xapi::JointAcc;
 using xapi::JointSpeed;
 using xapi::Mode;
-using xapi::MotionEnable;
+using xapi::MotionEnableMsg;
 using xapi::MoveCircleMsg;
 using xapi::PauseTime;
 using xapi::Position;
@@ -342,17 +342,17 @@ class XAPIClient {
         }*/
 
     // Enable the motion of the xArm (specific joints)
-    MotionEnable SetMotionEnable(const MotionEnable &motion_enable) {
+    MotionEnableMsg MotionEnable(const MotionEnableMsg &motion_enable) {
         // Context for the client. It could be used to convey extra information
         // to the server and/or tweak certain RPC behaviors.
         ClientContext context;
         // Container for the data we expect from the server.
-        MotionEnable motion_enable_res;
+        MotionEnableMsg motion_enable_msg_res;
 
         Status status =
-            stub_->SetMotionEnable(&context, motion_enable, &motion_enable_res);
+            stub_->MotionEnable(&context, motion_enable, &motion_enable_msg_res);
 
-        return motion_enable_res;
+        return motion_enable_msg_res;
     }
 
     // Set the xArm state
@@ -1158,16 +1158,16 @@ int main(int argc, char **argv) {
             grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
                                 grpc::InsecureChannelCredentials()));
         // Request Message
-        MotionEnable motion_enable_req;
-        motion_enable_req.set_enable(enable_flag);
-        motion_enable_req.set_servo_id(servo_option);
+        MotionEnableMsg motion_enable_msg;
+        motion_enable_msg.set_enable(enable_flag);
+        motion_enable_msg.set_servo_id(servo_option);
 
         // Response Message
-        MotionEnable motion_enable_res;
+        MotionEnableMsg motion_enable_msg_res;
 
-        motion_enable_res =
-            client.SetMotionEnable(motion_enable_req);  // The actual RPC call!
-        std::cout << "Response code: " << motion_enable_res.status_code()
+        motion_enable_msg_res =
+            client.MotionEnable(motion_enable_msg);  // The actual RPC call!
+        std::cout << "Response code: " << motion_enable_msg_res.status_code()
                   << std::endl;
     });
 #pragma endregion motion_enable

--- a/tools/xarm-commander/xarm_commander.cc
+++ b/tools/xarm-commander/xarm_commander.cc
@@ -16,19 +16,19 @@
 namespace constants {
 // Default values (to avoid magic numbers)
 // default cartesian position
-constexpr float kDefaultPosX = 300;
+constexpr float kDefaultPosX = 206;
 constexpr float kDefaultPosY = 0;
-constexpr float kDefaultPosZ = 200;
+constexpr float kDefaultPosZ = 120.5;
 constexpr float kDefaultPosRoll = 180;  // [Deg] by default
 constexpr float kDefaultPosPitch = 0;   // [Deg] by default
 constexpr float kDefaultPosYaw = 0;     // [Deg] by default
 // default servo angles
-constexpr float kDefaultAng1 = 1.75887;
-constexpr float kDefaultAng2 = -10.804;
-constexpr float kDefaultAng3 = -1.93244;
-constexpr float kDefaultAng4 = 16.7949;
+constexpr float kDefaultAng1 = 0;
+constexpr float kDefaultAng2 = 0;
+constexpr float kDefaultAng3 = 0;
+constexpr float kDefaultAng4 = 0;
 constexpr float kDefaultAng5 = 0;
-constexpr float kDefaultAng6 = 27.5947;
+constexpr float kDefaultAng6 = 0;
 constexpr float kDefaultAng7 = 0;
 
 constexpr int kAllServo = 8;
@@ -43,6 +43,7 @@ using grpc::Status;
 using xapi::Cmdnum;
 using xapi::CollisionSensitivity;
 using xapi::Currents;
+using xapi::DefaultIsRadian;
 using xapi::Empty;
 using xapi::InitParam;
 using xapi::Mode;
@@ -63,7 +64,6 @@ using xapi::Temperatures;
 using xapi::Version;
 using xapi::Voltages;
 using xapi::XAPI;
-using xapi::DefaultIsRadian;
 
 class XAPIClient {
    public:
@@ -141,7 +141,8 @@ class XAPIClient {
         Empty empty;
         ServoAngles servo_angles;
         ClientContext context;
-        Status status = stub_->GetLastUsedAngles(&context, empty, &servo_angles);
+        Status status =
+            stub_->GetLastUsedAngles(&context, empty, &servo_angles);
         return servo_angles;
     }
 
@@ -155,7 +156,7 @@ class XAPIClient {
         return temperatures;
     }
 
-    // Get the xArm default_is_radian 
+    // Get the xArm default_is_radian
     DefaultIsRadian GetDefaultIsRadian() {
         Empty empty;
         DefaultIsRadian default_is_radian;
@@ -264,6 +265,7 @@ class XAPIClient {
     }
 
     // ===== Write methods =====
+/* DEACTIVATED!
     // Set the xArm default_is_radian
     DefaultIsRadian SetDefaultIsRadian(
         const DefaultIsRadian &default_is_radian) {
@@ -274,10 +276,10 @@ class XAPIClient {
         DefaultIsRadian default_is_radian_res;
 
         Status status = stub_->SetDefaultIsRadian(&context, default_is_radian,
-                                                   &default_is_radian_res);
+                                                  &default_is_radian_res);
 
         return default_is_radian_res;
-    }
+    }*/
 
     // Enable the motion of the xArm (specific joints)
     MotionEnable SetMotionEnable(const MotionEnable &motion_enable) {
@@ -629,7 +631,6 @@ int main(int argc, char **argv) {
     });
 #pragma endregion get_last_used_angles
 
-
 #pragma region get_temperatures
     // Subcommand: get_temperatures
     auto *get_temperatures = app.add_subcommand(
@@ -837,14 +838,16 @@ int main(int argc, char **argv) {
 #pragma endregion get_position
 
     //----- Write methods -----
+/* DEACTIVATED!
 #pragma region set_default_is_radian
     // Subcommand: set_default_is_radian
     auto *set_default_is_radian = app.add_subcommand(
         "set_default_is_radian", "send a set_default_is_radian command");
 
     bool default_is_radian_option = false;
-    set_default_is_radian->add_option("-d", default_is_radian_option,
-                                      "set if the default unit is radians or not");
+    set_default_is_radian->add_option(
+        "-d", default_is_radian_option,
+        "set if the default unit is radians or not");
 
     set_default_is_radian->callback([&]() {
         XAPIClient client(
@@ -859,6 +862,7 @@ int main(int argc, char **argv) {
                   << std::endl;
     });
 #pragma endregion set_default_is_radian
+*/
 
 #pragma region motion_enable
     // Subcommand: motion_enable

--- a/tools/xarm-commander/xarm_commander.cc
+++ b/tools/xarm-commander/xarm_commander.cc
@@ -42,6 +42,7 @@ using grpc::ClientContext;
 using grpc::Status;
 using xapi::Cmdnum;
 using xapi::CollisionSensitivity;
+using xapi::Counter;
 using xapi::Currents;
 using xapi::DefaultIsRadian;
 using xapi::Empty;
@@ -599,6 +600,8 @@ class XAPIClient {
 
     // Turn on/off safety mode
     FenceMode SetFenceMode(const FenceMode &fence_mode) {
+        Empty empty;
+
         // Context for the client. It could be used to convey extra information
         // to the server and/or tweak certain RPC behaviors.
         ClientContext context;
@@ -609,6 +612,45 @@ class XAPIClient {
             stub_->SetFenceMode(&context, fence_mode, &fence_mode_res);
 
         return fence_mode_res;
+    }
+
+    // Get the xArm counter
+    Counter GetCounter() {
+        Empty empty;
+        Counter counter;
+        ClientContext context;
+        Status status = stub_->GetCounter(&context, empty, &counter);
+        return counter;
+    }
+
+    // Reset counter value
+    Counter SetCounterReset() {
+        Empty empty;
+
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        Counter counter;
+
+        Status status = stub_->SetCounterReset(&context, empty, &counter);
+
+        return counter;
+    }
+
+    // Set counter plus 1
+    Counter SetCounterIncrease() {
+        Empty empty;
+
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        Counter counter;
+
+        Status status = stub_->SetCounterIncrease(&context, empty, &counter);
+
+        return counter;
     }
 
     // Set the simulation robot
@@ -1832,6 +1874,55 @@ int main(int argc, char **argv) {
                   << std::endl;
     });
 #pragma endregion set_fence_mode
+
+#pragma region get_counter
+    // Subcommand: get_counter
+    auto *get_counter =
+        app.add_subcommand("get_counter", "send a get_counter command");
+
+    get_counter->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Counter counter_res;
+        counter_res = client.GetCounter();  // The actual RPC call!
+        std::cout << "Counter value: " << counter_res.counter() << std::endl;
+        std::cout << "Response code: " << counter_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion get_counter
+
+#pragma region set_counter_reset
+    // Subcommand: set_counter_reset
+    auto *set_counter_reset = app.add_subcommand(
+        "set_counter_reset", "send a set_counter_reset command");
+
+    set_counter_reset->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Counter counter_res;
+        counter_res = client.SetCounterReset();  // The actual RPC call!
+        std::cout << "Response code: " << counter_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion set_counter_reset
+
+#pragma region set_counter_increase
+    // Subcommand: set_counter_increase
+    auto *set_counter_increase = app.add_subcommand(
+        "set_counter_increase", "send a set_counter_increase command");
+
+    set_counter_increase->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Counter counter_res;
+        counter_res = client.SetCounterIncrease();  // The actual RPC call!
+        std::cout << "Response code: " << counter_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion set_counter_increase
 
 #pragma region set_simulation_robot
     // Subcommand: set_simulation_robot

--- a/tools/xarm-commander/xarm_commander.cc
+++ b/tools/xarm-commander/xarm_commander.cc
@@ -15,12 +15,22 @@
 
 namespace constants {
 // Default values (to avoid magic numbers)
+// default cartesian position
 constexpr float kDefaultPosX = 300;
 constexpr float kDefaultPosY = 0;
 constexpr float kDefaultPosZ = 200;
 constexpr float kDefaultPosRoll = 180;  // [Deg] by default
 constexpr float kDefaultPosPitch = 0;   // [Deg] by default
 constexpr float kDefaultPosYaw = 0;     // [Deg] by default
+// default servo angles
+constexpr float kDefaultAng1 = 0;
+constexpr float kDefaultAng2 = 0;
+constexpr float kDefaultAng3 = 0;
+constexpr float kDefaultAng4 = 0;
+constexpr float kDefaultAng5 = 0;
+constexpr float kDefaultAng6 = 0;
+constexpr float kDefaultAng7 = 0;
+
 constexpr int kAllServo = 8;
 constexpr int kLogInfo = 1;
 constexpr int kLogDebug = 2;
@@ -30,34 +40,20 @@ constexpr int kLogEval = 3;
 using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
+using xapi::Cmdnum;
+using xapi::CollisionSensitivity;
 using xapi::Empty;
 using xapi::InitParam;
 using xapi::Mode;
 using xapi::MotionEnable;
+using xapi::MoveCircleMsg;
 using xapi::Position;
+using xapi::ResetMsg;
+using xapi::ServoAngles;
 using xapi::State;
+using xapi::TeachSensitivity;
 using xapi::Version;
 using xapi::XAPI;
-
-/*
-class ClientApp: public CLI::App {
-public:
-    // XAPIClient
-    XAPIClient client;
-
-    // initialization after parsing and before callback
-    // overriding the virtual function
-    void pre_callback() override {
-        std::string server_ip;
-        std::string server_port;
-
-        client = new XAPIClient(
-                grpc::CreateChannel(fmt::format("{}:{}", server_ip,
-server_port), grpc::InsecureChannelCredentials())
-        );
-    }
-};
-*/
 
 class XAPIClient {
    public:
@@ -99,6 +95,28 @@ class XAPIClient {
     }
 
     // ===== Read methods =====
+    // Get the xArm collision sensitivity
+    CollisionSensitivity GetCollisionSensitivity() {
+        Empty empty;
+        CollisionSensitivity collision_sensitivity;
+        ClientContext context;
+        Status status = stub_->GetCollisionSensitivity(&context, empty,
+                                                       &collision_sensitivity);
+
+        return collision_sensitivity;
+    }
+
+    // Get the xArm teach sensitivity
+    TeachSensitivity GetTeachSensitivity() {
+        Empty empty;
+        TeachSensitivity teach_sensitivity;
+        ClientContext context;
+        Status status =
+            stub_->GetTeachSensitivity(&context, empty, &teach_sensitivity);
+
+        return teach_sensitivity;
+    }
+
     // Get the xArm version
     Version GetVersion() {
         Empty empty;
@@ -127,6 +145,16 @@ class XAPIClient {
         return state;
     }
 
+    // Get the cmd count in cache
+    Cmdnum GetCmdnum() {
+        Empty empty;
+        Cmdnum cmdnum;
+        ClientContext context;
+        Status status = stub_->GetCmdnum(&context, empty, &cmdnum);
+
+        return cmdnum;
+    }
+
     // Get the xArm position
     Position GetPosition() {
         Empty empty;
@@ -134,6 +162,15 @@ class XAPIClient {
         ClientContext context;
         Status status = stub_->GetPosition(&context, empty, &position);
         return position;
+    }
+
+    // Get the xArm servo angles
+    ServoAngles GetServoAngles() {
+        Empty empty;
+        ServoAngles servo_angles;
+        ClientContext context;
+        Status status = stub_->GetServoAngles(&context, empty, &servo_angles);
+        return servo_angles;
     }
 
     // ===== Write methods =====
@@ -178,6 +215,36 @@ class XAPIClient {
         return mode_res;
     }
 
+    // Set the xArm collision sensitivity
+    CollisionSensitivity SetCollisionSensitivity(
+        const CollisionSensitivity &collision_sensitivity) {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        CollisionSensitivity collision_sensitivity_res;
+
+        Status status = stub_->SetCollisionSensitivity(
+            &context, collision_sensitivity, &collision_sensitivity_res);
+
+        return collision_sensitivity_res;
+    }
+
+    // Set the xArm teach sensitivity
+    TeachSensitivity SetTeachSensitivity(
+        const TeachSensitivity &teach_sensitivity) {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        TeachSensitivity teach_sensitivity_res;
+
+        Status status = stub_->SetTeachSensitivity(&context, teach_sensitivity,
+                                                   &teach_sensitivity_res);
+
+        return teach_sensitivity_res;
+    }
+
     // Set the xArm position
     Position SetPosition(const Position &position) {
         // Context for the client. It could be used to convey extra information
@@ -189,6 +256,61 @@ class XAPIClient {
         Status status = stub_->SetPosition(&context, position, &position_res);
 
         return position_res;
+    }
+
+    // Set the xArm servo_angles
+    ServoAngles SetServoAngles(const ServoAngles &servo_angles) {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        ServoAngles servo_angles_res;
+
+        Status status =
+            stub_->SetServoAngles(&context, servo_angles, &servo_angles_res);
+
+        return servo_angles_res;
+    }
+
+    // The motion calculates the trajectory of the space circle according to the
+    // three-point coordinates.
+    MoveCircleMsg MoveCircle(const MoveCircleMsg &move_circle) {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        MoveCircleMsg move_circle_res;
+
+        Status status =
+            stub_->MoveCircle(&context, move_circle, &move_circle_res);
+
+        return move_circle_res;
+    }
+
+    // Emergency stop
+    void EmergencyStop() {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        Empty empty;
+
+        Status status = stub_->EmergencyStop(&context, empty, &empty);
+
+        return;
+    }
+
+    // Reset
+    void Reset(const ResetMsg &reset) {
+        // Context for the client. It could be used to convey extra information
+        // to the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        // Container for the data we expect from the server.
+        Empty empty;
+
+        Status status = stub_->Reset(&context, reset, &empty);
+
+        return;
     }
 
    private:
@@ -240,7 +362,9 @@ int main(int argc, char **argv) {
     app.require_subcommand(1);  // set max number of subcommands to 1
 
     // ----- Connection specific -----
+#pragma region disconnect
     // Subcommand: disconnect
+
     auto *disconnect = app.add_subcommand("disconnect", "disconnect from xArm");
     disconnect->callback([&]() {
         XAPIClient client(
@@ -250,9 +374,12 @@ int main(int argc, char **argv) {
         std::cout << "Disconnected" << std::endl;
     });
 
+#pragma endregion disconnect
+
+#pragma region initialize
     // Subcommand: initialize
-    std::string xarm_ip = "192.168.0.2";
     auto *initialize = app.add_subcommand("initialize", "initialize XArmAPI");
+    std::string xarm_ip = "192.168.0.2";
     initialize->add_option("-x, --xarm_ip", xarm_ip,
                            "ip-address of xArm control box");
     initialize->callback([&]() {
@@ -262,9 +389,47 @@ int main(int argc, char **argv) {
         client.Initialize(xarm_ip);  // The actual RPC call!
         std::cout << "Initialized" << std::endl;
     });
+#pragma endregion initialize
 
     // ----- Read methods -----
+#pragma region get_collision_sensitivity
+    // Subcommand: get_collision_sensitivity
+    auto *get_collision_sensitivity =
+        app.add_subcommand("get_collision_sensitivity",
+                           "send a get_collision_sensitivity command");
+    get_collision_sensitivity->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        CollisionSensitivity collision_sensitivity;
+        collision_sensitivity =
+            client.GetCollisionSensitivity();  // The actual RPC call!
+        std::cout << "Collision sensitivity: "
+                  << collision_sensitivity.collision_sensitivity() << std::endl;
+        std::cout << "Response code: " << collision_sensitivity.status_code()
+                  << std::endl;
+    });
+#pragma endregion get_collision_sensitivity
 
+#pragma region get_teach_sensitivity
+    // Subcommand: get_teach_sensitivity
+    auto *get_teach_sensitivity = app.add_subcommand(
+        "get_teach_sensitivity", "send a get_teach_sensitivity command");
+    get_teach_sensitivity->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        TeachSensitivity teach_sensitivity;
+        teach_sensitivity =
+            client.GetTeachSensitivity();  // The actual RPC call!
+        std::cout << "Teach sensitivity: "
+                  << teach_sensitivity.teach_sensitivity() << std::endl;
+        std::cout << "Response code: " << teach_sensitivity.status_code()
+                  << std::endl;
+    });
+#pragma endregion get_teach_sensitivity
+
+#pragma region get_version
     // Subcommand: get_version
     auto *get_version =
         app.add_subcommand("get_version", "send a get_version command");
@@ -277,7 +442,9 @@ int main(int argc, char **argv) {
         std::cout << "Version: " << version.version() << std::endl;
         std::cout << "Response code: " << version.status_code() << std::endl;
     });
+#pragma endregion get_version
 
+#pragma region get_state
     // Subcommand: get_state
     auto *get_state =
         app.add_subcommand("get_state", "send a get_state commmand");
@@ -290,8 +457,47 @@ int main(int argc, char **argv) {
         std::cout << "State: " << state.state() << std::endl;
         std::cout << "Response code: " << state.status_code() << std::endl;
     });
+#pragma endregion get_state
 
-    
+#pragma region get_cmdnum
+    // Subcommand: get_cmdnum
+    auto *get_cmdnum =
+        app.add_subcommand("get_cmdnum", "send a get_cmdnum commmand");
+    get_cmdnum->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Cmdnum cmdnum;
+        cmdnum = client.GetCmdnum();  // The actual RPC call!
+        std::cout << "Cmdnum: " << cmdnum.cmdnum() << std::endl;
+        std::cout << "Response code: " << cmdnum.status_code() << std::endl;
+    });
+#pragma endregion get_cmdnum
+
+#pragma region get_servo_angles
+    // Subcommand: get_servo_angles
+    auto *get_servo_angles = app.add_subcommand(
+        "get_servo_angles", "send a get_servo_angles command");
+    get_servo_angles->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        ServoAngles servo_angles;
+        servo_angles = client.GetServoAngles();  // The actual RPC call!
+        std::cout << "ServoAngles: \n"
+                  << "    \"servo_1\": " << servo_angles.servo_1() << "\n"
+                  << "    \"servo_2\": " << servo_angles.servo_2() << "\n"
+                  << "    \"servo_3\": " << servo_angles.servo_3() << "\n"
+                  << "    \"servo_4\": " << servo_angles.servo_4() << "\n"
+                  << "    \"servo_5\": " << servo_angles.servo_5() << "\n"
+                  << "    \"servo_6\": " << servo_angles.servo_6() << "\n"
+                  << "    \"servo_7\": " << servo_angles.servo_7() << std::endl;
+        std::cout << "Response code: " << servo_angles.status_code()
+                  << std::endl;
+    });
+#pragma endregion get_servo_angles
+
+#pragma region get_position
     // Subcommand: get_position
     auto *get_position = app.add_subcommand(
         "get_position",
@@ -311,9 +517,10 @@ int main(int argc, char **argv) {
                   << "    \"yaw\": " << position.yaw() << std::endl;
         std::cout << "Response code: " << position.status_code() << std::endl;
     });
+#pragma endregion get_position
 
     //----- Write methods -----
-    
+#pragma region motion_enable
     // Subcommand: motion_enable
     auto *motion_enable =
         app.add_subcommand("motion_enable", "send a motion_enable command");
@@ -346,7 +553,9 @@ int main(int argc, char **argv) {
         std::cout << "Response code: " << motion_enable_res.status_code()
                   << std::endl;
     });
+#pragma endregion motion_enable
 
+#pragma region set_state
     // Subcommand: set_state
     auto *set_state =
         app.add_subcommand("set_state", "send a set_state command");
@@ -365,7 +574,9 @@ int main(int argc, char **argv) {
         state_res = client.SetState(state);  // The actual RPC call!
         std::cout << "Response code: " << state_res.status_code() << std::endl;
     });
+#pragma endregion set_state
 
+#pragma region set_mode
     // Subcommand: set_mode
     auto *set_mode = app.add_subcommand("set_mode", "send a set_mode command");
 
@@ -386,8 +597,57 @@ int main(int argc, char **argv) {
         mode_res = client.SetMode(mode);  // The actual RPC call!
         std::cout << "Response code: " << mode_res.status_code() << std::endl;
     });
+#pragma endregion set_mode
 
+#pragma region set_collision_sensitivity
+    // Subcommand: set_collision_sensitivity
+    auto *set_collision_sensitivity =
+        app.add_subcommand("set_collision_sensitivity",
+                           "send a set_collision_sensitivity command");
 
+    int collision_sensitivity_option = 0;
+    set_collision_sensitivity->add_option("-m", collision_sensitivity_option,
+                                          "collision sensitivity value, 0~5");
+
+    set_collision_sensitivity->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        CollisionSensitivity collision_sensitivity;
+        CollisionSensitivity collision_sensitivity_res;
+        collision_sensitivity.set_collision_sensitivity(
+            collision_sensitivity_option);
+        collision_sensitivity_res = client.SetCollisionSensitivity(
+            collision_sensitivity);  // The actual RPC call!
+        std::cout << "Response code: "
+                  << collision_sensitivity_res.status_code() << std::endl;
+    });
+#pragma endregion set_collision_sensitivity
+
+#pragma region set_teach_sensitivity
+    // Subcommand: set_teach_sensitivity
+    auto *set_teach_sensitivity = app.add_subcommand(
+        "set_teach_sensitivity", "send a set_teach_sensitivity command");
+
+    int teach_sensitivity_option = 0;
+    set_teach_sensitivity->add_option("-m", teach_sensitivity_option,
+                                      "teach sensitivity value, 0~5");
+
+    set_teach_sensitivity->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        TeachSensitivity teach_sensitivity;
+        TeachSensitivity teach_sensitivity_res;
+        teach_sensitivity.set_teach_sensitivity(teach_sensitivity_option);
+        teach_sensitivity_res = client.SetTeachSensitivity(
+            teach_sensitivity);  // The actual RPC call!
+        std::cout << "Response code: " << teach_sensitivity_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion set_teach_sensitivity
+
+#pragma region set_postion
     // Subcommand: set_position
     auto *set_position = app.add_subcommand(
         "set_position",
@@ -428,6 +688,186 @@ int main(int argc, char **argv) {
         std::cout << "Response code: " << position_res.status_code()
                   << std::endl;
     });
+#pragma endregion set_postion
+
+#pragma region set_servo_angles
+    // Subcommand: set_servo_angles
+    auto *set_servo_angles = app.add_subcommand(
+        "set_servo_angles", "send a set_servo_angles command");
+
+    float servo_1_option = constants::kDefaultAng1;
+    set_servo_angles->add_option("-1", servo_1_option, "servo-1(rad or °)");
+    float servo_2_option = constants::kDefaultAng2;
+    set_servo_angles->add_option("-2", servo_2_option, "servo-2(rad or °)");
+    float servo_3_option = constants::kDefaultAng3;
+    set_servo_angles->add_option("-3", servo_3_option, "servo-3(rad or °)");
+    float servo_4_option = constants::kDefaultAng4;
+    set_servo_angles->add_option("-4", servo_4_option, "servo-4(rad or °)");
+    float servo_5_option = constants::kDefaultAng5;
+    set_servo_angles->add_option("-5", servo_5_option, "servo-5(rad or °)");
+    float servo_6_option = constants::kDefaultAng6;
+    set_servo_angles->add_option("-6", servo_6_option, "servo-6(rad or °)");
+    float servo_7_option = constants::kDefaultAng7;
+    set_servo_angles->add_option("-7", servo_7_option, "servo-7(rad or °)");
+
+    wait_option = false;  // TODO(jo-bru): namespace/scope
+    set_servo_angles->add_option("--wait", wait_option,
+                                 "whether to wait for the arm to complete");
+
+    set_servo_angles->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        ServoAngles servo_angles;
+        ServoAngles servo_angles_res;
+        servo_angles.set_servo_1(servo_1_option);
+        servo_angles.set_servo_2(servo_2_option);
+        servo_angles.set_servo_3(servo_3_option);
+        servo_angles.set_servo_4(servo_4_option);
+        servo_angles.set_servo_5(servo_5_option);
+        servo_angles.set_servo_6(servo_6_option);
+        servo_angles.set_servo_7(servo_7_option);
+
+        servo_angles.set_wait(wait_option);
+
+        servo_angles_res =
+            client.SetServoAngles(servo_angles);  // The actual RPC call!
+        std::cout << "Response code: " << servo_angles_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion set_servo_angles
+
+#pragma region move_circle
+    // Subcommand: move_circle
+    auto *move_circle =
+        app.add_subcommand("move_circle", "send a move_circle command");
+
+    float x1_option = constants::kDefaultPosX;
+    move_circle->add_option("--x1", x1_option, "x1(mm)");
+    float y1_option = constants::kDefaultPosYaw;
+    move_circle->add_option("--y1", y1_option, "y1(mm)");
+    float z1_option = constants::kDefaultPosZ;
+    move_circle->add_option("--z1", z1_option, "z1(mm)");
+    float roll1_option = constants::kDefaultPosRoll;
+    move_circle->add_option("--r1, --roll1", roll1_option, "roll1(rad or °)");
+    float pitch1_option = constants::kDefaultPosPitch;
+    move_circle->add_option("--p1, --pitch1", pitch1_option,
+                            "pitch1(rad or °)");
+    float yaw1_option = constants::kDefaultPosYaw;
+    move_circle->add_option("--w1, --yaw1", yaw1_option, "yaw1(rad or °)");
+
+    float x2_option = constants::kDefaultPosX;
+    move_circle->add_option("--x2", x2_option, "x2(mm)");
+    float y2_option = constants::kDefaultPosYaw;
+    move_circle->add_option("--y2", y2_option, "y2(mm)");
+    float z2_option = constants::kDefaultPosZ;
+    move_circle->add_option("--z2", z2_option, "z2(mm)");
+    float roll2_option = constants::kDefaultPosRoll;
+    move_circle->add_option("--r2, --roll2", roll2_option, "roll2(rad or °)");
+    float pitch2_option = constants::kDefaultPosPitch;
+    move_circle->add_option("--p2, --pitch2", pitch2_option,
+                            "pitch2(rad or °)");
+    float yaw2_option = constants::kDefaultPosYaw;
+    move_circle->add_option("--w2, --yaw2", yaw2_option, "yaw2(rad or °)");
+
+    float percent_option = 0;
+    move_circle->add_option(
+        "--percent", percent_option,
+        "the percentage of arc length and circumference of the movement");
+    float speed_option = 0;
+    move_circle->add_option(
+        "--speed", speed_option,
+        "move speed (mm/s, rad/s), default(0) is the last_used_tcp_speed");
+    float acc_option = 0;
+    move_circle->add_option("--acc", acc_option,
+                            "move acceleration (mm/s^2, rad/s^2), default(0) "
+                            "is the last_used_tcp_acc");
+
+    wait_option = false;
+    move_circle->add_option("--wait", wait_option,
+                            "whether to wait for the arm to complete");
+    float timeout_option = -1;
+    move_circle->add_option(
+        "--timeout", timeout_option,
+        "maximum waiting time(unit: second), -1: no timeout");
+
+    move_circle->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Position *pose_1 = new Position();
+        pose_1->set_x(x1_option);
+        pose_1->set_y(y1_option);
+        pose_1->set_z(z1_option);
+        pose_1->set_roll(roll1_option);
+        pose_1->set_pitch(pitch1_option);
+        pose_1->set_yaw(yaw1_option);
+
+        Position *pose_2 = new Position();
+        pose_2->set_x(x2_option);
+        pose_2->set_y(y2_option);
+        pose_2->set_z(z2_option);
+        pose_2->set_roll(roll2_option);
+        pose_2->set_pitch(pitch2_option);
+        pose_2->set_yaw(yaw2_option);
+
+        MoveCircleMsg move_circle;
+        move_circle.set_allocated_pose_1(pose_1);
+        move_circle.set_allocated_pose_2(pose_2);
+
+        move_circle.set_percent(percent_option);
+        move_circle.set_speed(speed_option);
+        move_circle.set_acc(acc_option);
+        move_circle.set_wait(wait_option);
+        move_circle.set_timeout(timeout_option);
+
+        MoveCircleMsg move_circle_res;
+
+        move_circle_res =
+            client.MoveCircle(move_circle);  // The actual RPC call!
+        std::cout << "Response code: " << move_circle_res.status_code()
+                  << std::endl;
+    });
+#pragma endregion set_move_circle
+
+#pragma region emergency_stop
+    // Subcommand: emergency_stop
+    auto *emergency_stop =
+        app.add_subcommand("emergency_stop", "send an emergency_stop command");
+
+    emergency_stop->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        client.EmergencyStop();  // The actual RPC call!
+        std::cout << "Stopped" << std::endl;
+    });
+#pragma endregion emergency_stop
+
+#pragma region reset
+    // Subcommand: reset
+    auto *reset = app.add_subcommand("reset", "send a reset command");
+
+    wait_option = false;
+    set_teach_sensitivity->add_option(
+        "--wait", wait_option, "whether to wait for the arm to complete");
+
+    timeout_option = -1;
+    set_teach_sensitivity->add_option(
+        "--timeout", timeout_option,
+        "maximum waiting time(unit: second), -1: no timeout");
+
+    reset->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        ResetMsg reset;
+        reset.set_wait(wait_option);
+        reset.set_timeout(timeout_option);
+        client.Reset(reset);  // The actual RPC call!
+        std::cout << "Reset sent." << std::endl;
+    });
+#pragma endregion reset
 
     CLI11_PARSE(app, argc, argv);
 

--- a/tools/xarm-commander/xarm_commander.cc
+++ b/tools/xarm-commander/xarm_commander.cc
@@ -46,6 +46,8 @@ using xapi::Currents;
 using xapi::DefaultIsRadian;
 using xapi::Empty;
 using xapi::InitParam;
+using xapi::JointAcc;
+using xapi::JointSpeed;
 using xapi::Mode;
 using xapi::MotionEnable;
 using xapi::MoveCircleMsg;
@@ -59,6 +61,8 @@ using xapi::SetPositionMsg;
 using xapi::SetServoAngleMsg;
 using xapi::SimulationRobot;
 using xapi::State;
+using xapi::TCPAcc;
+using xapi::TCPSpeed;
 using xapi::TeachSensitivity;
 using xapi::Temperatures;
 using xapi::Version;
@@ -136,6 +140,47 @@ class XAPIClient {
         return teach_sensitivity;
     }
 
+    // Get the xArm last used TCP speed
+    TCPSpeed GetLastUsedTCPSpeed() {
+        Empty empty;
+        TCPSpeed tcp_speed;
+        ClientContext context;
+        Status status = stub_->GetLastUsedTCPSpeed(&context, empty, &tcp_speed);
+
+        return tcp_speed;
+    }
+
+    // Get the xArm last used TCP acceleration
+    TCPAcc GetLastUsedTCPAcc() {
+        Empty empty;
+        TCPAcc tcp_acc;
+        ClientContext context;
+        Status status = stub_->GetLastUsedTCPAcc(&context, empty, &tcp_acc);
+
+        return tcp_acc;
+    }
+
+    // Get the xArm last used Joint speed
+    JointSpeed GetLastUsedJointSpeed() {
+        Empty empty;
+        JointSpeed joint_speed;
+        ClientContext context;
+        Status status =
+            stub_->GetLastUsedJointSpeed(&context, empty, &joint_speed);
+
+        return joint_speed;
+    }
+
+    // Get the xArm last used Joint acceleration
+    JointAcc GetLastUsedJointAcc() {
+        Empty empty;
+        JointAcc joint_acc;
+        ClientContext context;
+        Status status = stub_->GetLastUsedJointAcc(&context, empty, &joint_acc);
+
+        return joint_acc;
+    }
+
     // Get the xArm last used servo angles
     ServoAngles GetLastUsedAngles() {
         Empty empty;
@@ -144,6 +189,15 @@ class XAPIClient {
         Status status =
             stub_->GetLastUsedAngles(&context, empty, &servo_angles);
         return servo_angles;
+    }
+
+    // Get the xArm last used tcp position
+    Position GetLastUsedPosition() {
+        Empty empty;
+        Position position;
+        ClientContext context;
+        Status status = stub_->GetLastUsedPosition(&context, empty, &position);
+        return position;
     }
 
     // Get the xArm motor temperatures
@@ -265,21 +319,22 @@ class XAPIClient {
     }
 
     // ===== Write methods =====
-/* DEACTIVATED!
-    // Set the xArm default_is_radian
-    DefaultIsRadian SetDefaultIsRadian(
-        const DefaultIsRadian &default_is_radian) {
-        // Context for the client. It could be used to convey extra information
-        // to the server and/or tweak certain RPC behaviors.
-        ClientContext context;
-        // Container for the data we expect from the server.
-        DefaultIsRadian default_is_radian_res;
+    /* DEACTIVATED!
+        // Set the xArm default_is_radian
+        DefaultIsRadian SetDefaultIsRadian(
+            const DefaultIsRadian &default_is_radian) {
+            // Context for the client. It could be used to convey extra
+       information
+            // to the server and/or tweak certain RPC behaviors.
+            ClientContext context;
+            // Container for the data we expect from the server.
+            DefaultIsRadian default_is_radian_res;
 
-        Status status = stub_->SetDefaultIsRadian(&context, default_is_radian,
-                                                  &default_is_radian_res);
+            Status status = stub_->SetDefaultIsRadian(&context,
+       default_is_radian, &default_is_radian_res);
 
-        return default_is_radian_res;
-    }*/
+            return default_is_radian_res;
+        }*/
 
     // Enable the motion of the xArm (specific joints)
     MotionEnable SetMotionEnable(const MotionEnable &motion_enable) {
@@ -608,6 +663,68 @@ int main(int argc, char **argv) {
     });
 #pragma endregion get_teach_sensitivity
 
+#pragma region get_last_used_tcp_speed
+    // Subcommand: get_last_used_tcp_speed
+    auto *get_last_used_tcp_speed = app.add_subcommand(
+        "get_last_used_tcp_speed", "send a get_last_used_tcp_speed command");
+    get_last_used_tcp_speed->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        TCPSpeed tcp_speed;
+        tcp_speed = client.GetLastUsedTCPSpeed();  // The actual RPC call!
+        std::cout << "TCP Speed: " << tcp_speed.tcp_speed() << std::endl;
+        std::cout << "Response code: " << tcp_speed.status_code() << std::endl;
+    });
+#pragma endregion get_last_used_tcp_speed
+
+#pragma region get_last_used_tcp_acc
+    // Subcommand: get_last_used_tcp_acc
+    auto *get_last_used_tcp_acc = app.add_subcommand(
+        "get_last_used_tcp_acc", "send a get_last_used_tcp_acc command");
+    get_last_used_tcp_acc->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        TCPAcc tcp_acc;
+        tcp_acc = client.GetLastUsedTCPAcc();  // The actual RPC call!
+        std::cout << "TCP Acc: " << tcp_acc.tcp_acc() << std::endl;
+        std::cout << "Response code: " << tcp_acc.status_code() << std::endl;
+    });
+#pragma endregion get_last_used_tcp_acc
+
+#pragma region get_last_used_joint_speed
+    // Subcommand: get_last_used_joint_speed
+    auto *get_last_used_joint_speed =
+        app.add_subcommand("get_last_used_joint_speed",
+                           "send a get_last_used_joint_speed command");
+    get_last_used_joint_speed->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        JointSpeed joint_speed;
+        joint_speed = client.GetLastUsedJointSpeed();  // The actual RPC call!
+        std::cout << "Joint Speed: " << joint_speed.joint_speed() << std::endl;
+        std::cout << "Response code: " << joint_speed.status_code()
+                  << std::endl;
+    });
+#pragma endregion get_last_used_joint_speed
+
+#pragma region get_last_used_joint_acc
+    // Subcommand: get_last_used_joint_acc
+    auto *get_last_used_joint_acc = app.add_subcommand(
+        "get_last_used_joint_acc", "send a get_last_used_joint_acc command");
+    get_last_used_joint_acc->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        JointAcc joint_acc;
+        joint_acc = client.GetLastUsedJointAcc();  // The actual RPC call!
+        std::cout << "Joint Acc: " << joint_acc.joint_acc() << std::endl;
+        std::cout << "Response code: " << joint_acc.status_code() << std::endl;
+    });
+#pragma endregion get_last_used_joint_acc
+
 #pragma region get_last_used_angles
     // Subcommand: get_last_used_angles
     auto *get_last_used_angles = app.add_subcommand(
@@ -630,6 +747,27 @@ int main(int argc, char **argv) {
                   << std::endl;
     });
 #pragma endregion get_last_used_angles
+
+#pragma region get_last_used_position
+    // Subcommand: get_last_used_position
+    auto *get_last_used_position = app.add_subcommand(
+        "get_last_used_position", "send a get_last_used_position command");
+    get_last_used_position->callback([&]() {
+        XAPIClient client(
+            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
+                                grpc::InsecureChannelCredentials()));
+        Position position;
+        position = client.GetLastUsedPosition();  // The actual RPC call!
+        std::cout << "Position: \n"
+                  << "    \"x\": " << position.x() << "\n"
+                  << "    \"y\": " << position.y() << "\n"
+                  << "    \"z\": " << position.z() << "\n"
+                  << "    \"roll\": " << position.roll() << "\n"
+                  << "    \"pitch\": " << position.pitch() << "\n"
+                  << "    \"yaw\": " << position.yaw() << std::endl;
+        std::cout << "Response code: " << position.status_code() << std::endl;
+    });
+#pragma endregion get_last_used_position
 
 #pragma region get_temperatures
     // Subcommand: get_temperatures
@@ -838,31 +976,31 @@ int main(int argc, char **argv) {
 #pragma endregion get_position
 
     //----- Write methods -----
-/* DEACTIVATED!
-#pragma region set_default_is_radian
-    // Subcommand: set_default_is_radian
-    auto *set_default_is_radian = app.add_subcommand(
-        "set_default_is_radian", "send a set_default_is_radian command");
+    /* DEACTIVATED!
+    #pragma region set_default_is_radian
+        // Subcommand: set_default_is_radian
+        auto *set_default_is_radian = app.add_subcommand(
+            "set_default_is_radian", "send a set_default_is_radian command");
 
-    bool default_is_radian_option = false;
-    set_default_is_radian->add_option(
-        "-d", default_is_radian_option,
-        "set if the default unit is radians or not");
+        bool default_is_radian_option = false;
+        set_default_is_radian->add_option(
+            "-d", default_is_radian_option,
+            "set if the default unit is radians or not");
 
-    set_default_is_radian->callback([&]() {
-        XAPIClient client(
-            grpc::CreateChannel(fmt::format("{}:{}", server_ip, server_port),
-                                grpc::InsecureChannelCredentials()));
-        DefaultIsRadian default_is_radian;
-        DefaultIsRadian default_is_radian_res;
-        default_is_radian.set_default_is_radian(default_is_radian_option);
-        default_is_radian_res = client.SetDefaultIsRadian(
-            default_is_radian);  // The actual RPC call!
-        std::cout << "Response code: " << default_is_radian_res.status_code()
-                  << std::endl;
-    });
-#pragma endregion set_default_is_radian
-*/
+        set_default_is_radian->callback([&]() {
+            XAPIClient client(
+                grpc::CreateChannel(fmt::format("{}:{}", server_ip,
+    server_port), grpc::InsecureChannelCredentials())); DefaultIsRadian
+    default_is_radian; DefaultIsRadian default_is_radian_res;
+            default_is_radian.set_default_is_radian(default_is_radian_option);
+            default_is_radian_res = client.SetDefaultIsRadian(
+                default_is_radian);  // The actual RPC call!
+            std::cout << "Response code: " <<
+    default_is_radian_res.status_code()
+                      << std::endl;
+        });
+    #pragma endregion set_default_is_radian
+    */
 
 #pragma region motion_enable
     // Subcommand: motion_enable

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -21,6 +21,8 @@ using xapi::Currents;
 using xapi::DefaultIsRadian;
 using xapi::Empty;
 using xapi::InitParam;
+using xapi::JointAcc;
+using xapi::JointSpeed;
 using xapi::Mode;
 using xapi::MotionEnable;
 using xapi::MoveCircleMsg;
@@ -34,6 +36,8 @@ using xapi::SetPositionMsg;
 using xapi::SetServoAngleMsg;
 using xapi::SimulationRobot;
 using xapi::State;
+using xapi::TCPAcc;
+using xapi::TCPSpeed;
 using xapi::TeachSensitivity;
 using xapi::Temperatures;
 using xapi::Version;
@@ -86,6 +90,42 @@ class XAPIServiceImpl final : public XAPI::Service {
         return Status::OK;
     }
 
+    Status GetLastUsedTCPSpeed(ServerContext* context, const Empty* empty,
+                               TCPSpeed* tcp_speed) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32 tcp_speed_tmp = api->last_used_tcp_speed;
+        tcp_speed->set_tcp_speed(tcp_speed_tmp);
+        tcp_speed->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetLastUsedTCPAcc(ServerContext* context, const Empty* empty,
+                             TCPAcc* tcp_acc) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32 tcp_acc_tmp = api->last_used_tcp_acc;
+        tcp_acc->set_tcp_acc(tcp_acc_tmp);
+        tcp_acc->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetLastUsedJointSpeed(ServerContext* context, const Empty* empty,
+                                 JointSpeed* joint_speed) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32 joint_speed_tmp = api->last_used_joint_speed;
+        joint_speed->set_joint_speed(joint_speed_tmp);
+        joint_speed->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetLastUsedJointAcc(ServerContext* context, const Empty* empty,
+                               JointAcc* joint_acc) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32 joint_acc_tmp = api->last_used_joint_acc;
+        joint_acc->set_joint_acc(joint_acc_tmp);
+        joint_acc->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
     Status GetLastUsedAngles(ServerContext* context, const Empty* empty,
                              ServoAngles* servo_angles) override {
         int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
@@ -99,6 +139,21 @@ class XAPIServiceImpl final : public XAPI::Service {
         servo_angles->set_servo_6(*(angles + 5));
         servo_angles->set_servo_7(*(angles + 6));
         servo_angles->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetLastUsedPosition(ServerContext* context, const Empty* empty,
+                               Position* position) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32* pose;
+        pose = api->last_used_position;
+        position->set_x(*(pose));
+        position->set_y(*(pose + 1));
+        position->set_z(*(pose + 2));
+        position->set_roll(*(pose + 3));
+        position->set_pitch(*(pose + 4));
+        position->set_yaw(*(pose + 5));
+        position->set_status_code(status_code_tmp);
         return Status::OK;
     }
 
@@ -249,16 +304,16 @@ class XAPIServiceImpl final : public XAPI::Service {
     }
 
     // ===== Write methods =====
-    
-/* DEACTIVATED! 
-    Status SetDefaultIsRadian(ServerContext* context,
-                              const DefaultIsRadian* default_is_radian,
-                              DefaultIsRadian* default_is_radian_res) override {
-        int status_code_tmp = 0;
-        api->default_is_radian = default_is_radian->default_is_radian();
-        default_is_radian_res->set_status_code(status_code_tmp);
-        return Status::OK;
-    }*/
+
+    /* DEACTIVATED!
+        Status SetDefaultIsRadian(ServerContext* context,
+                                  const DefaultIsRadian* default_is_radian,
+                                  DefaultIsRadian* default_is_radian_res)
+       override { int status_code_tmp = 0; api->default_is_radian =
+       default_is_radian->default_is_radian();
+            default_is_radian_res->set_status_code(status_code_tmp);
+            return Status::OK;
+        }*/
 
     Status SetMotionEnable(ServerContext* context,
                            const MotionEnable* motion_enable,

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -25,6 +25,7 @@ using xapi::MoveCircleMsg;
 using xapi::Position;
 using xapi::ResetMsg;
 using xapi::ServoAngles;
+using xapi::SimulationRobot;
 using xapi::State;
 using xapi::TeachSensitivity;
 using xapi::Version;
@@ -63,6 +64,15 @@ class XAPIServiceImpl final : public XAPI::Service {
         int teach_sensitivity_tmp = api->teach_sensitivity;
         teach_sensitivity->set_teach_sensitivity(teach_sensitivity_tmp);
         teach_sensitivity->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetSimulationRobot(ServerContext* context, const Empty* empty,
+                              SimulationRobot* simulation_robot) override {
+        int status_code_tmp = 0;
+        bool is_simulation_robot = api->is_simulation_robot;
+        simulation_robot->set_on(is_simulation_robot);
+        simulation_robot->set_status_code(status_code_tmp);
         return Status::OK;
     }
 
@@ -269,9 +279,9 @@ class XAPIServiceImpl final : public XAPI::Service {
         return Status::OK;
     }
 
-
-    Status GetInverseKinematics(ServerContext* context, const Position* position,
-                       ServoAngles* servo_angles) override {
+    Status GetInverseKinematics(ServerContext* context,
+                                const Position* position,
+                                ServoAngles* servo_angles) override {
         int status_code_tmp;
         fp32 pose[6];
         pose[0] = position->x();
@@ -297,8 +307,8 @@ class XAPIServiceImpl final : public XAPI::Service {
     }
 
     Status GetForwardKinematics(ServerContext* context,
-                          const ServoAngles* servo_angles,
-                          Position* position) override {
+                                const ServoAngles* servo_angles,
+                                Position* position) override {
         int status_code_tmp;
         fp32 angles[6];
         angles[0] = servo_angles->servo_1();
@@ -319,6 +329,15 @@ class XAPIServiceImpl final : public XAPI::Service {
         position->set_pitch(pose[4]);
         position->set_yaw(pose[5]);
         position->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status SetSimulationRobot(ServerContext* context,
+                              const SimulationRobot* simulation_robot,
+                              SimulationRobot* simulation_robot_res) override {
+        int status_code_tmp;
+        status_code_tmp = api->set_simulation_robot(simulation_robot->on());
+        simulation_robot_res->set_status_code(status_code_tmp);
         return Status::OK;
     }
 

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -18,6 +18,7 @@ using grpc::Status;
 using xapi::Cmdnum;
 using xapi::CollisionSensitivity;
 using xapi::Currents;
+using xapi::DefaultIsRadian;
 using xapi::Empty;
 using xapi::InitParam;
 using xapi::Mode;
@@ -85,6 +86,22 @@ class XAPIServiceImpl final : public XAPI::Service {
         return Status::OK;
     }
 
+    Status GetLastUsedAngles(ServerContext* context, const Empty* empty,
+                             ServoAngles* servo_angles) override {
+        int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
+        fp32* angles;
+        angles = api->last_used_angles;
+        servo_angles->set_servo_1(*(angles));
+        servo_angles->set_servo_2(*(angles + 1));
+        servo_angles->set_servo_3(*(angles + 2));
+        servo_angles->set_servo_4(*(angles + 3));
+        servo_angles->set_servo_5(*(angles + 4));
+        servo_angles->set_servo_6(*(angles + 5));
+        servo_angles->set_servo_7(*(angles + 6));
+        servo_angles->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
     Status GetTemperatures(ServerContext* context, const Empty* empty,
                            Temperatures* temperatures) override {
         int status_code_tmp = 0;  // TODO(jo-bru): status code for properties
@@ -98,6 +115,15 @@ class XAPIServiceImpl final : public XAPI::Service {
         temperatures->set_servo_6(*(temp + 5));
         temperatures->set_servo_7(*(temp + 6));
         temperatures->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status GetDefaultIsRadian(ServerContext* context, const Empty* empty,
+                              DefaultIsRadian* default_is_radian) override {
+        int status_code_tmp = 0;
+        bool default_is_radian_tmp = api->default_is_radian;
+        default_is_radian->set_default_is_radian(default_is_radian_tmp);
+        default_is_radian->set_status_code(status_code_tmp);
         return Status::OK;
     }
 
@@ -223,6 +249,15 @@ class XAPIServiceImpl final : public XAPI::Service {
     }
 
     // ===== Write methods =====
+    Status SetDefaultIsRadian(ServerContext* context,
+                              const DefaultIsRadian* default_is_radian,
+                              DefaultIsRadian* default_is_radian_res) override {
+        int status_code_tmp = 0;
+        api->default_is_radian = default_is_radian->default_is_radian();
+        default_is_radian_res->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
     Status SetMotionEnable(ServerContext* context,
                            const MotionEnable* motion_enable,
                            MotionEnable* motion_enable_res) override {

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -249,6 +249,8 @@ class XAPIServiceImpl final : public XAPI::Service {
     }
 
     // ===== Write methods =====
+    
+/* DEACTIVATED! 
     Status SetDefaultIsRadian(ServerContext* context,
                               const DefaultIsRadian* default_is_radian,
                               DefaultIsRadian* default_is_radian_res) override {
@@ -256,7 +258,7 @@ class XAPIServiceImpl final : public XAPI::Service {
         api->default_is_radian = default_is_radian->default_is_radian();
         default_is_radian_res->set_status_code(status_code_tmp);
         return Status::OK;
-    }
+    }*/
 
     Status SetMotionEnable(ServerContext* context,
                            const MotionEnable* motion_enable,
@@ -363,8 +365,6 @@ class XAPIServiceImpl final : public XAPI::Service {
 
         // oneof: single angle or all angles
         if (set_servo_angle_msg->has_servo_angle()) {
-            std::cout << "Singe angle.."
-                      << "\n";
             int servo_id = set_servo_angle_msg->servo_angle().servo_id();
             fp32 angle = set_servo_angle_msg->servo_angle().angle();
 

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -47,6 +47,7 @@ class XAPIServiceImpl final : public XAPI::Service {
         std::string version_str(
             version_char,
             version_char + sizeof version_char / sizeof version_char[0]);
+        version_str.resize(version_str.find('\0'));
         version->set_version(version_str);
         version->set_status_code(status_code);
         return Status::OK;
@@ -78,7 +79,7 @@ class XAPIServiceImpl final : public XAPI::Service {
     }
 
     // ===== Write methods =====
-        Status SetMotionEnable(ServerContext* context,
+    Status SetMotionEnable(ServerContext* context,
                            const MotionEnable* motion_enable,
                            MotionEnable* motion_enable_res) override {
         int status_code_tmp;

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -269,6 +269,59 @@ class XAPIServiceImpl final : public XAPI::Service {
         return Status::OK;
     }
 
+
+    Status GetInverseKinematics(ServerContext* context, const Position* position,
+                       ServoAngles* servo_angles) override {
+        int status_code_tmp;
+        fp32 pose[6];
+        pose[0] = position->x();
+        pose[1] = position->y();
+        pose[2] = position->z();
+        pose[3] = position->roll();
+        pose[4] = position->yaw();
+        pose[5] = position->pitch();
+
+        fp32 angles[7];
+        status_code_tmp = api->get_inverse_kinematics(pose, angles);
+
+        servo_angles->set_servo_1(angles[0]);
+        servo_angles->set_servo_2(angles[1]);
+        servo_angles->set_servo_3(angles[2]);
+        servo_angles->set_servo_4(angles[3]);
+        servo_angles->set_servo_5(angles[4]);
+        servo_angles->set_servo_6(angles[5]);
+        servo_angles->set_servo_7(angles[6]);
+        servo_angles->set_status_code(status_code_tmp);
+
+        return Status::OK;
+    }
+
+    Status GetForwardKinematics(ServerContext* context,
+                          const ServoAngles* servo_angles,
+                          Position* position) override {
+        int status_code_tmp;
+        fp32 angles[6];
+        angles[0] = servo_angles->servo_1();
+        angles[1] = servo_angles->servo_2();
+        angles[2] = servo_angles->servo_3();
+        angles[3] = servo_angles->servo_4();
+        angles[4] = servo_angles->servo_5();
+        angles[5] = servo_angles->servo_6();
+        angles[6] = servo_angles->servo_7();
+
+        fp32 pose[6];
+        status_code_tmp = api->get_forward_kinematics(angles, pose);
+
+        position->set_x(pose[0]);
+        position->set_y(pose[1]);
+        position->set_z(pose[2]);
+        position->set_roll(pose[3]);
+        position->set_pitch(pose[4]);
+        position->set_yaw(pose[5]);
+        position->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
     XArmAPI* api;
 };
 

--- a/xarm_grpc_service.cc
+++ b/xarm_grpc_service.cc
@@ -47,6 +47,8 @@ using xapi::Temperatures;
 using xapi::Version;
 using xapi::Voltages;
 using xapi::XAPI;
+using xapi::Counter;
+
 
 // XAPI server
 class XAPIServiceImpl final : public XAPI::Service {
@@ -644,6 +646,33 @@ class XAPIServiceImpl final : public XAPI::Service {
         fence_mode_res->set_status_code(status_code_tmp);
         return Status::OK;
     }
+
+
+    Status GetCounter(ServerContext* context, const Empty* empty,
+                          Counter* counter) override {
+        int status_code_tmp = 0;
+        int counter_tmp = api->count;
+        counter->set_counter(counter_tmp);
+        counter->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status SetCounterReset(ServerContext* context, const Empty* empty,
+                          Counter* counter) override {
+
+        int status_code_tmp = api->set_counter_reset();
+        counter->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+
+    Status SetCounterIncrease(ServerContext* context, const Empty* empty,
+                          Counter* counter) override {
+
+        int status_code_tmp = api->set_counter_increase();
+        counter->set_status_code(status_code_tmp);
+        return Status::OK;
+    }
+    
 
     Status SetSimulationRobot(ServerContext* context,
                               const SimulationRobot* simulation_robot,


### PR DESCRIPTION
This PR extends the `xarm-commander` and `xarm-grpc-service` functionality.
The following methods are newly implemented:

Motion related methods:
- `SetPosition`: additional support for adapting speed, acceleration, arc transitions
- `SetServoAngle`
- `MoveCircle
- `SetPauseTime`: to add pause between movements
- `GetServoAngles`
- `LastUsed` values: `Position`, `TCPSpeed`, `TCPAcc`, `Angles`, `JointSpeed`, `JointAcc`

System actions:
- `Reset`: not yet tested (see #48)
- `EmergencyStop`: not yet tested (see #48)

General System Properties:
- `GetMode`
- `GetDefaultIsRadian`: `SetDefaultIsRadian` is deactivated since its usage may be dangerous without further safety measures (see #46 ).
- `GetRobotSN`: does not work yet (see #43 )
- `GetCmdnum`: not yet tested well (see #47)
- `Get/SetCollisionSensitivity`
- `Get/SetTeachSensitivity`

Safety settings:
- Reduced Mode: Joint range and collision rebound not yet supported
- Safety Boundary: `GetFence/SafetyMode` not yet supported

Other:
- Advanced properties: `Temperatures`, `Voltages`, `Currents`
- Kinematics: `GetInverseKinematics`, `GetForwardKinematics`
- Simulation: `Get/SetSimulationRobot` switch between simulation and real => all other commands can also be used for the simulated robot!
- Counter: `GetCounter`, `SetCounterReset`, `SetCounterIncrease`

There are still interesting methods that need to be implemented. However, I wanted to go on and implement first these methods in the Servient and then come back to further implement other methods.

Other interesting methods to implement are:
- Trajectory related methods
- Gripper related methods
- TCP settings
- Error/warn handing